### PR TITLE
Requirements calls need to match the composer package vendor

### DIFF
--- a/src/GoogleMapField.php
+++ b/src/GoogleMapField.php
@@ -179,8 +179,8 @@ class GoogleMapField extends FormField {
 			$gmapsParams['key'] = $key;
 		}
 		$this->extend('updateGoogleMapsParams', $gmapsParams);
-        Requirements::css('betterbrief/silverstripe-googlemapfield: client/css/GoogleMapField.css');
-        Requirements::javascript('betterbrief/silverstripe-googlemapfield: client/js/GoogleMapField.js');
+        Requirements::css('innoweb/silverstripe-googlemapfield: client/css/GoogleMapField.css');
+        Requirements::javascript('innoweb/silverstripe-googlemapfield: client/js/GoogleMapField.js');
 		Requirements::javascript('//maps.googleapis.com/maps/api/js?' . http_build_query($gmapsParams));
 	}
 


### PR DESCRIPTION
The calls to `Requirements` are trying to include assets from the `betterbrief` vendor name, these two lines need to be updated to match the updated `innoweb` vendor for the assets to load. 